### PR TITLE
html_escape needed, at least with Redmine 2.2

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -13,13 +13,8 @@ end
 Redmine::WikiFormatting::Macros.register do
   desc "Macro for add javascript and css files for table sort work"
   macro :sortable_table do |obj, args|
-    content_for :header_tags do
-      "  %s\n  %s" % [
-        javascript_include_tag( "tablesort.js", :plugin => 'sortable_table'),
-        stylesheet_link_tag( :default, :plugin => 'sortable_table')
-      ]
-    end
+    content_for :header_tags, javascript_include_tag( "tablesort.js", :plugin => 'sortable_table').html_safe
+    content_for :header_tags, stylesheet_link_tag( :default, :plugin => 'sortable_table').html_safe
     ""
   end
 end
-


### PR DESCRIPTION
Hi.
I just ran your plugin with a clean Redmine 2.2.0 install, but it was not working out of the box: The script and style tags where escaped and because of that not working. 
So I simply split the content_for array into two calls, giving each call the tag with .html_safe. That way the plugins worked like a charm. Perhaps not the most elegant way ... ;)

Some more information about my environment:
Ubuntu 12.10
Ruby 1.8.7
Rails 3.2.9
Redmine 2.2.0

Kind regards,
Daniel
